### PR TITLE
Fix contact email address

### DIFF
--- a/legal_privacy.dart
+++ b/legal_privacy.dart
@@ -43,7 +43,7 @@ class PrivacyPolicyScreen extends StatelessWidget {
           _H('Changes'),
           _P('We may update this policy. Material changes will be posted in-app and on this page. Continued use constitutes acceptance.'),
           _H('Contact'),
-          _P('For privacy questions or requests, contact: Bisan Idrees (Israel) – gmaildepthnoteapp@gmail.com'),
+          _P('For privacy questions or requests, contact: Bisan Idrees (Israel) – depthnoteapp@gmail.com'),
         ],
       ),
     );

--- a/privacy.html
+++ b/privacy.html
@@ -58,6 +58,6 @@
   <p>We may update this policy. Material changes will be posted in‑app and on this page. Continued use constitutes acceptance.</p>
 
   <h2>Contact</h2>
-  <p>For privacy questions or requests, contact: Bisan Idrees (Israel) – <a href="mailto:gmaildepthnoteapp@gmail.com">gmaildepthnoteapp@gmail.com</a></p>
+  <p>For privacy questions or requests, contact: Bisan Idrees (Israel) – <a href="mailto:depthnoteapp@gmail.com">depthnoteapp@gmail.com</a></p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the privacy HTML contact email to depthnoteapp@gmail.com
- align the Flutter privacy screen contact text with the corrected email address

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d536d238048327a99a7bd2942c7f47