### PR TITLE
Add delete account policy page

### DIFF
--- a/delete_account.html
+++ b/delete_account.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Depth Note – Delete Account</title>
+  <style>
+    body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif; line-height: 1.6; margin: 24px; max-width: 900px; }
+    h1, h2 { line-height: 1.2; }
+    ul { padding-left: 20px; }
+    .muted { color: #555; }
+    code { background: #f3f3f3; padding: 2px 4px; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Delete your Depth Note account</h1>
+  <p class="muted">Last updated: 2025-09-25</p>
+
+  <h2>How to delete your account in the app</h2>
+  <ol>
+    <li>Open Depth Note.</li>
+    <li>Go to <strong>Settings</strong>.</li>
+    <li>Tap <strong>Delete account</strong> and confirm.</li>
+  </ol>
+  <p>This permanently deletes your Depth Note account (Firebase user) that is associated with your sign‑in method (Google or Apple).</p>
+
+  <h2>What data is deleted</h2>
+  <ul>
+    <li>Your account identifier and authentication record (Firebase Auth).</li>
+    <li>Your purchase association with the account in RevenueCat (your app entitlement will no longer be associated to the deleted user). Note: store receipts remain with Apple/Google for billing records.</li>
+  </ul>
+
+  <h2>What data is retained</h2>
+  <ul>
+    <li><strong>Purchase history/receipts</strong> retained by Apple/Google and RevenueCat for fraud prevention, tax, and audit requirements.</li>
+    <li><strong>Crash logs/diagnostics</strong> that may contain device/app metadata already sent prior to deletion; these are automatically aged out by providers.</li>
+    <li><strong>Notes and images saved locally</strong> on your device. These are not uploaded to our servers; uninstalling the app removes local data unless you exported it.</li>
+  </ul>
+
+  <h2>Subscriptions</h2>
+  <p>Deleting your Depth Note account <strong>does not cancel</strong> an active subscription. To cancel:</p>
+  <ul>
+    <li>Apple: open App Store → Account → Subscriptions.</li>
+    <li>Google: open Play Store → Payments & subscriptions → Subscriptions.</li>
+  </ul>
+
+  <h2>Contact</h2>
+  <p>For deletion issues or to request export/deletion assistance, contact: <strong>Bisan Idrees (Israel)</strong> – <a href="mailto:gmaildepthnoteapp@gmail.com">gmaildepthnoteapp@gmail.com</a></p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a static HTML page describing the account deletion process for Depth Note users
- outline the data removed, retained, and steps to cancel subscriptions
- include contact information for assistance

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d53e26da1483279f051fc8f385d657